### PR TITLE
Feat: create RadioGroup with basic functional

### DIFF
--- a/app/UI/RadioGroup/RadioGroup.tsx
+++ b/app/UI/RadioGroup/RadioGroup.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import RadioGroupItem from "./RadioGroupItem";
+
+export type TInput = {
+  id: string;
+  value: string;
+  title: string;
+  subtitle: string;
+  tags?: string[];
+};
+
+export default function RadioGroup({ inputs }: { inputs: TInput[] }) {
+  const [selectedValue, setSelectedValue] = useState("");
+
+  const handleChange = (value: string) => {
+    setSelectedValue(value);
+  };
+
+  return (
+    <form className="flex gap-4">
+      {inputs.map((input) => (
+        <RadioGroupItem
+          key={input.id}
+          id={input.id}
+          value={input.value}
+          title={input.title}
+          subtitle={input.subtitle}
+          tags={input.tags}
+          groupName="radioGroup"
+          checked={selectedValue === input.value}
+          onChange={handleChange}
+        />
+      ))}
+    </form>
+  );
+}

--- a/app/UI/RadioGroup/RadioGroupItem.tsx
+++ b/app/UI/RadioGroup/RadioGroupItem.tsx
@@ -1,0 +1,66 @@
+import { TInput } from "./RadioGroup";
+
+type RadioGroupItemProps = TInput & {
+  groupName: string;
+  checked: boolean;
+  onChange: (value: string) => void;
+};
+
+export default function RadioGroupItem({
+  id,
+  value,
+  subtitle,
+  tags,
+  groupName,
+  title,
+  checked,
+  onChange,
+}: RadioGroupItemProps) {
+  let isBestDeal: boolean = false;
+
+  if (tags?.find((tag) => tag === "bestDeal")) isBestDeal = true;
+
+  const handleClick = () => {
+    onChange(value);
+  };
+
+  return (
+    <div
+      key={id}
+      className={`border-2 rounded-xl p-4 relative flex gap-2 ${
+        isBestDeal
+          ? "border-primary bg-secondary"
+          : "border-background bg-background/80"
+      }`}
+    >
+      {isBestDeal && (
+        <div className="bg-primary text-white text-center w-fit px-2 py-1 text-xs font-normal tracking-wider rounded-full absolute -top-[20%] right-1/2 translate-x-1/2">
+          BEST DEAL
+        </div>
+      )}
+
+      <div>
+        <div
+          className={`w-8 h-8 cursor-pointer rounded-full border-8 bg-white ${
+            checked ? "border-primary" : "border-white"
+          }`}
+          onClick={handleClick}
+        />
+        <input
+          className="hidden"
+          type="radio"
+          id={id}
+          value={value}
+          name={groupName}
+          checked={checked}
+          onChange={handleClick}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div>{title}</div>
+        <div className="text-xs font-normal">{subtitle}</div>
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,30 @@
+import RadioGroup from "./UI/RadioGroup/RadioGroup";
+
 export default function Home() {
+  const inputs = [
+    {
+      id: "threeSticks",
+      value: "threeSticks",
+      title: "3 Sticks(-32%)",
+      subtitle: "$64.00/each",
+      tags: ["bestDeal"],
+    },
+    {
+      id: "twoSticks",
+      value: "twoSticks",
+      title: "2 Sticks(-22%)",
+      subtitle: "$71.00/each",
+    },
+    {
+      id: "oneSticks",
+      value: "oneSticks",
+      title: "1 Sticks(-15%)",
+      subtitle: "$75.00",
+    },
+  ];
   return (
-    <div className="text-xl font-bold">
-      Create a RadioGroup component and use it here
+    <div className="text-xl font-bold p-12">
+      <RadioGroup inputs={inputs} groupName="sticksGroup" />
     </div>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,7 +6,15 @@ const config: Config = {
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
-  theme: {},
+  theme: {
+    extend: {
+      colors: {
+        primary: "#5a58f2",
+        secondary: "#ECEBFE",
+        background: "#DEE2EA",
+      },
+    },
+  },
   plugins: [],
 };
 export default config;


### PR DESCRIPTION
I'm not really sure, why should we create RadioGroup component, I'm more familliar with concept of creating RadioInput, and then using it where necessary, It's much more flexible that way, and it doesn't suffer from props drilling and just easier to work with, but I've done it like you descibed on README file.
You also asked me to suggest how would I've done it if I had more time, and honestly I'd just cut RadioGroup component as a whole, and just use RadioGroupItem(I'd rename it in RadioInput) where needed.