### PR TITLE
feat. radiogroup added

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,34 @@
-export default function Home() {
+"use client";
+
+import { useState } from "react";
+import RadioGroup from "../components/RadioGroup";
+
+const options = [
+  {
+    label: "3 Sticks (-32%)",
+    value: "option1",
+    price: "$64.00/each",
+    badge: "BEST DEAL",
+  },
+  { label: "2 Sticks (-22%)", value: "option2", price: "$71.00/each" },
+  { label: "1 Stick (-15%)", value: "option3", price: "$75.00" },
+];
+
+const Home: React.FC = () => {
+  const [selectedOption, setSelectedOption] = useState<string>("option1");
+
   return (
-    <div className="text-xl font-bold">
-      Create a RadioGroup component and use it here
+    <div className="p-4">
+      <h1 id="radio-group-label" className="text-xl mb-4">
+        Select Your Package
+      </h1>
+      <RadioGroup
+        options={options}
+        value={selectedOption}
+        onChange={setSelectedOption}
+      />
     </div>
   );
-}
+};
+
+export default Home;

--- a/components/RadioGroup/RadioGroup.tsx
+++ b/components/RadioGroup/RadioGroup.tsx
@@ -1,0 +1,74 @@
+interface Option {
+  label: string;
+  value: string;
+  price: string;
+  badge?: string;
+}
+
+interface RadioGroupProps {
+  options: Option[];
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const RadioGroup: React.FC<RadioGroupProps> = ({
+  options,
+  value,
+  onChange,
+}) => {
+  return (
+    <div
+      className="flex space-x-4"
+      role="radiogroup"
+      aria-labelledby="radio-group-label"
+    >
+      {options.map((option) => (
+        <div
+          key={option.value}
+          className={`relative cursor-pointer p-4 rounded-lg ${
+            value === option.value
+              ? "border-2 border-blue-500 bg-blue-50"
+              : "bg-gray-200"
+          }`}
+        >
+          <input
+            type="radio"
+            id={option.value}
+            name="radio-group"
+            value={option.value}
+            checked={value === option.value}
+            onChange={() => onChange(option.value)}
+            className="hidden"
+          />
+          <label
+            htmlFor={option.value}
+            className="flex items-center space-x-2 cursor-pointer"
+          >
+            <div
+              className={`w-5 h-5 border-2 rounded-full ${
+                value === option.value
+                  ? "border-blue-600 bg-blue-600"
+                  : "border-gray-400"
+              }`}
+            >
+              {value === option.value && (
+                <div className="w-2 h-2 bg-white rounded-full ml-[4px] mt-[4px]"></div>
+              )}
+            </div>
+            <div>
+              <span className="font-semibold">{option.label}</span>
+              <div className="text-sm text-gray-600">{option.price}</div>
+            </div>
+          </label>
+          {option.badge && (
+            <div className="absolute top-0 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-blue-500 text-white text-xs py-1 px-2 rounded-full">
+              {option.badge}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default RadioGroup;

--- a/components/RadioGroup/index.ts
+++ b/components/RadioGroup/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RadioGroup";


### PR DESCRIPTION
The radiogroup has been made keeping in mind the simplicity, accessibility, reusability and modularity. This can be used most places without much changes needed. 
In the future, given enough time, theme using primary and secondary colors can be introduced. If a user wants to use this radiogroup, they can pass primary and secondary colors as props and use this radiogroup according to their theme.  Similar further changes can be made as well as further accessibility use cases are defined.