### PR TITLE
Add RadioGroup component and integrate it into the homepage

### DIFF
--- a/app/components/RadioGroup.tsx
+++ b/app/components/RadioGroup.tsx
@@ -1,0 +1,60 @@
+"use client";
+import React from "react";
+
+interface PricingOptionProps {
+  label: string;
+  price: string;
+  discount: string;
+  bestDeal?: boolean;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+const RadioGroup: React.FC<PricingOptionProps> = ({
+  label,
+  price,
+  discount,
+  bestDeal,
+  selected,
+  onSelect,
+}) => {
+  return (
+    <div
+      className={`relative flex flex-col items-center p-6 mx-2 my-4 rounded-[24px] ${
+        selected
+          ? "bg-purple-100 border-2 border-purple-500"
+          : "bg-gray-100 border-2 border-[#C0C6D6]"
+      } cursor-pointer w-full sm:w-[90%] md:w-[80%] lg:w-1/3`}
+      onClick={onSelect}
+    >
+      {selected && bestDeal && (
+        <div className="absolute top-0 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-purple-500 px-4 py-2 rounded-[8px] font-normal text-lg text-white">
+          BEST DEAL
+        </div>
+      )}
+
+      <div className="flex items-center w-[80%]">
+        <div
+          className={`w-11 h-11 rounded-full border-2 ${
+            selected
+              ? "border-purple-500 bg-purple-500 flex items-center justify-center"
+              : "border-[#C0C6D6]"
+          }`}
+        >
+          {selected && <div className="w-5 h-5 rounded-full bg-white"></div>}
+        </div>
+        <div className="flex items-center ml-4 font-bold text-black">
+          <div className="text-[30px] font-bold text-black">{label}</div>
+          <div className="text-[30px] ml-2 ">{discount}</div>
+        </div>
+      </div>
+
+      <div className="flex items-center w-[80%]">
+        <div className="w-6 h-6 rounded-full border-2 invisible"></div>
+        <div className="text-[18px] font-normal ml-[2.25rem]">{price}</div>
+      </div>
+    </div>
+  );
+};
+
+export default RadioGroup;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,34 @@
+"use client";
+import React, { useState } from "react";
+import PricingOption from "./components/RadioGroup";
 export default function Home() {
+  const [selectedOption, setSelectedOption] = useState<number>(3);
   return (
     <div className="text-xl font-bold">
-      Create a RadioGroup component and use it here
+      <div className="flex flex-col lg:flex-row justify-center items-center p-4">
+        <PricingOption
+          label="3 Sticks"
+          price="$64.00/each"
+          discount="(-32%)"
+          bestDeal={true}
+          selected={selectedOption === 3}
+          onSelect={() => setSelectedOption(3)}
+        />
+        <PricingOption
+          label="2 Sticks"
+          price="$71.00/each"
+          discount="(-22%)"
+          selected={selectedOption === 2}
+          onSelect={() => setSelectedOption(2)}
+        />
+        <PricingOption
+          label="1 Stick"
+          price="$75.00"
+          discount="(-15%)"
+          selected={selectedOption === 1}
+          onSelect={() => setSelectedOption(1)}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
If I had more time, I would have created separate components for the radio button and the text aligned with it, and used them twice in the main RadioGroup component. This would enhance reusability and make the code more modular and easier to maintain.